### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 
 INSTALLDIR=/usr/local/bin
 GLIBS=-lm -lpthread
-GENERIC_SRC=mem_share.h string.h file_reader.h file_reader.c bitvec.h hashset.h sort.h list.h dna.h thread.h timer.h
+GENERIC_SRC=mem_share.h string.h file_reader.h file_reader.c bitvec.h hashset.h sort.h list.h dna.h thread.h
 
 PROGS=wtdbg wtdbg-cns
 


### PR DESCRIPTION
 No rule to make target `timer.h', needed by`wtdbg'.  Stop.
